### PR TITLE
[FIX] Update .env - renamed language variable

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ ODOO_EXTRA_ADDONS=/mnt/extra-addons
 # Modules
 BASE_MODULES=base
 INSTALL_MODULES=base
-LOAD_LANGUAGES=
+INSTALL_LANGUAGES=
 
 # Auto Install dependencies or run Tests
 PIP_AUTO_INSTALL=1


### PR DESCRIPTION
LOAD_LANGUAGES renamed to INSTALL_LANGUAGES in .env file while this variable name is used in entrypoint.sh