### PR TITLE
Remove generation of /etc/odoo/odoo.conf

### DIFF
--- a/.env
+++ b/.env
@@ -21,7 +21,7 @@ UPGRADE_ENABLE=0
 DEBUGPY_ENABLE=1
 
 # Odoo Configuration file defaults
-ADMIN_PASSWORD=admin
+ODOO_ADMIN_PASSWD=admin
 PGDATABASE=odoo
 # PGDATABASE_TEMPLATE=template0
 # PGSSLMODE=prefer

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,6 @@ run pip install --prefix=/usr --no-cache-dir --upgrade \
 # Create user and mounts
 # /var/lib/odoo for filestore and HOME
 # /mnt/extra-addons for users addons
-env ODOO_RC /etc/odoo/odoo.conf
 env ODOO_BASE_ADDONS=/opt/odoo-addons
 env ODOO_EXTRA_ADDONS=/mnt/extra-addons
 env PYTHON_DIST_PACKAGES=/usr/lib/python3/dist-packages
@@ -74,7 +73,8 @@ run mkdir -p /etc/odoo \
 	&& useradd --system --no-create-home --home-dir "${ODOO_DATA_DIR}" --shell /bin/bash odoo \
     && userdel ubuntu \
     && chown -R odoo:odoo /etc/odoo "${ODOO_BASE_ADDONS}" "${ODOO_EXTRA_ADDONS}" "${ODOO_DATA_DIR}" \
-    && chmod 775 /etc/odoo "${ODOO_DATA_DIR}" \
+    && chmod 551 /etc/odoo \
+    && chmod 775 "${ODOO_DATA_DIR}" \
     && echo "${ODOO_BASEPATH}" > "$PYTHON_DIST_PACKAGES/odoo.pth" \
     && ln -s "${ODOO_BASEPATH}/odoo-bin" /usr/bin/odoo-bin
 volume ["${ODOO_DATA_DIR}"]

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -8,23 +8,14 @@ export PGHOST PGPORT PGUSER PGPASSWORD
 ODOO_BIN="$ODOO_BASEPATH/odoo-bin"
 : ${ODOO_BASE_ADDONS:=/opt/odoo-addons}
 : ${ODOO_EXTRA_ADDONS:=/mnt/extra-addons}
-EXTRA_ADDONS_PATHS=$(odoo-getaddons.py ${ODOO_EXTRA_ADDONS} ${ODOO_BASE_ADDONS} ${ODOO_BASEPATH})
+ODOO_ADDONS_PATH=$(odoo-getaddons.py ${ODOO_EXTRA_ADDONS} ${ODOO_BASE_ADDONS} ${ODOO_BASEPATH})
+export ODOO_ADDONS_PATH
 
-if [ ! -f "${ODOO_RC}" ]
+if [ -n "$ODOO_ADDONS_PATH" ]
 then
-    echo "ENTRY - Generate $ODOO_RC"
-    cat > $ODOO_RC <<EOF
-[options]
-addons_path = ${EXTRA_ADDONS_PATHS}
-admin_passwd = ${ADMIN_PASSWORD:-admin}
-EOF
+    echo "ENTRY - Addons paths: $ODOO_ADDONS_PATH"
 fi
-
-if [ -n "$EXTRA_ADDONS_PATHS" ]
-then
-    echo "ENTRY - Addons paths: $EXTRA_ADDONS_PATHS"
-fi
-if [ -n "$EXTRA_ADDONS_PATHS" ] && [ "${PIP_AUTO_INSTALL:-0}" -eq "1" ]
+if [ -n "$ODOO_ADDONS_PATH" ] && [ "${PIP_AUTO_INSTALL:-0}" -eq "1" ]
 then
     for ADDON_PATH in "$ODOO_BASE_ADDONS" "$ODOO_EXTRA_ADDONS"
     do
@@ -78,6 +69,7 @@ case "${1:-}" in
             for db in ${ODOO_DB_LIST}
             do
                 echo "ENTRY - Update database: ${db}"
+                : ${ODOO_RC:=/etc/odoo/odoo.conf}
                 click-odoo-update --ignore-core-addons -d "$db" -c "$ODOO_RC" --log-level=error
                 echo "ENTRY - Update database finished"
             done


### PR DESCRIPTION
Since configuration is now passed by environment, we can remove the generation of the odoo.conf file.